### PR TITLE
Support multiple IDs in query

### DIFF
--- a/src/query.js
+++ b/src/query.js
@@ -35,10 +35,9 @@ const query = geneId => ({
 			code: 'C'
 		},
 		{
-			path: 'Gene',
-			op: 'LOOKUP',
-			value: geneId,
-			extraValue: 'H. sapiens',
+			path: 'Gene.id',
+			op: 'ONE OF',
+			values: geneId,
 			code: 'A'
 		},
 		{


### PR DESCRIPTION
I was using this tool to test the new tool initialisation in Bluegenes and noticed a problem with the query.

This can be tricky if you're not familiar with the [PathQuery API](https://intermine.readthedocs.io/en/latest/api/pathquery/) so here's a short explanation:
- `LOOKUP` only allows searching a single gene, so we have to use `ONE OF` instead
- `ONE OF` doesn't work on classes so we have to change the path to the gene id attribute with `Gene.id` 
- Not sure if changing `value` to `values` key is necessary, but it seems customary when using `ONE OF` and passing an array
- `extraValue` is context-dependent and filters the organism when used to lookup a gene, it won't do anything with `ONE OF` and we don't want to limit organisms either so we'll remove it

Please test that it works with *demo.html*. [=